### PR TITLE
Add title to the LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2013-2015 Erik Ekman <yarrick@kryo.se>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose


### PR DESCRIPTION
As described in https://github.com/yarrick/iodine/pull/45, the title is not legally mandated, but it's convenient for human consumption, and provides additional metadata; for that reason, it is typically included in the template text of this license, as recommended by [OSI](https://opensource.org/licenses/isc-license), [SPDX](https://spdx.org/licenses/ISC.html#licenseText), [choosealicense.com](https://choosealicense.com/licenses/isc/), and others.